### PR TITLE
95 - fix a11y issues with alert bar

### DIFF
--- a/source/03-components/alert-bar/alert-bar.scss
+++ b/source/03-components/alert-bar/alert-bar.scss
@@ -16,17 +16,13 @@
   padding: gesso-spacing(3) 0;
   width: 100%;
 
-  a {
+  * {
     color: inherit;
     text-decoration-color: currentColor;
   }
 
   p:last-child {
     margin-bottom: 0;
-  }
-
-  .c-kicker {
-    color: inherit;
   }
 
   .c-icon {

--- a/templates/misc/sitewide-alert.html.twig
+++ b/templates/misc/sitewide-alert.html.twig
@@ -21,9 +21,10 @@
  * @ingroup themeable
  */
 #}
-{% include '@components/alert-bar/alert-bar.twig' with {
+<aside role="complementary">
+  {% include '@components/alert-bar/alert-bar.twig' with {
   alert_kicker: content.field_kicker|field_value,
   alert_content: content|without('field_kicker'),
   alert_type: style
 } %}
-
+</aside>


### PR DESCRIPTION
- adds a 'complementary' landmark around the alert bar (seemed like the best fit)
- enforce inherited colors inside - we will probably still want Lynn to update the field for basic formatting only, but this will make sure any styling doesn't break contrast