### PR TITLE
fix QA issues with tabs

### DIFF
--- a/source/02-layouts/header/header.es6.js
+++ b/source/02-layouts/header/header.es6.js
@@ -116,6 +116,7 @@ Drupal.behaviors.header = {
       header.addEventListener('transitionend', updateHeaderCurrentHeight);
       window.addEventListener('scroll', updateScrollProgress);
       window.addEventListener('resize', debounce(setInitialHeights, 200));
+      window.addEventListener('scroll', debounce(updateHeaderCurrentHeight, 200));
       header.addEventListener('toggle-mobile-menu', () => {
         window.requestAnimationFrame(() => {
           setInitialHeights();

--- a/source/03-components/tabs/tabs.scss
+++ b/source/03-components/tabs/tabs.scss
@@ -11,8 +11,9 @@
   overflow-x: auto;
   padding-inline: gesso-site-margins(mobile);
   position: sticky;
-  top: var(--gesso-header-current-height, 0);
+  top: calc(var(--gesso-header-current-height, 0) + var(--ginToolbarHeight, 0));
   width: calc(100% + #{2 * gesso-site-margins(mobile)});
+  z-index: gesso-z-index(overlay);
 
   li {
     flex: 1 0 calc(25% - 10px);

--- a/templates/paragraph/paragraph--table.html.twig
+++ b/templates/paragraph/paragraph--table.html.twig
@@ -40,10 +40,14 @@
 #}
 
 {% set table %}
-  <div class="table-wrapper">{{ content }}</div>
+<div class="table-wrapper" tabindex="0">
+  {{ content }}
+</div>
 {% endset %}
 
-{% if is_nested %}{{ table }}{% else %}
+{% if is_nested %}
+  {{ table }}
+{% else %}
   {% include '@layouts/section/section.twig' with {
     section_content: table,
     has_constrain: true,


### PR DESCRIPTION
I haven't noticed any performance change from adding the scroll listener, but let me know if you're concerned.

The tabindex around the table to make it scrollable comes from [here](https://www.tpgi.com/short-note-on-improving-usability-of-scrollable-regions/) - I actually was able to focus & arrow-key it already, maybe my browser settings are different, but this should ensure that's universal.