### PR TITLE
72 - add 'news' label to news article cards

### DIFF
--- a/source/03-components/kicker/_kicker.scss
+++ b/source/03-components/kicker/_kicker.scss
@@ -9,7 +9,7 @@
   color: var(--gesso-text-color);
   font-size: rem(gesso-font-size(1));
   font-weight: gesso-font-weight(bold);
-  letter-spacing: 0.05em;
+  letter-spacing: 0.15em;
   margin-bottom: 0;
   text-transform: uppercase;
 

--- a/templates/content/node--news-article--card.html.twig
+++ b/templates/content/node--news-article--card.html.twig
@@ -110,8 +110,8 @@
 {% include '@components/card/card.twig' with {
   'title': label,
   'url': card_link,
-  'kicker': kicker,
-  'type': content.field_type|field_value,
+  'type': 'News',
+  'kicker': content.field_type|field_value,
   'footer': footer,
   'media': card_media,
   'card_content': card_content,


### PR DESCRIPTION
The kicker style also got more spaced-out at some point, based on figma.