### PR TITLE
111 - higher z-index for lightbox

### DIFF
--- a/source/00-config/config.design-tokens.yml
+++ b/source/00-config/config.design-tokens.yml
@@ -409,6 +409,7 @@ gesso:
     modal: 499
     nav: 500
     drawer: 501
+    lightbox: 502
   spacing:
     0: 0
     0.5: 4px

--- a/source/03-components/media-lightbox/media-lightbox.scss
+++ b/source/03-components/media-lightbox/media-lightbox.scss
@@ -17,7 +17,7 @@
   position: fixed;
   top: 0;
   width: 100vw;
-  z-index: gesso-z-index(modal);
+  z-index: gesso-z-index(lightbox);
 
   @media (max-height: 450px) {
     padding-top: rem(gesso-spacing(8));


### PR DESCRIPTION
Setting it to 501 still puts it behind the logged-in admin bar, have to go a bit higher.