### PR TITLE
129 - fix spacing issues inside event cards

### DIFF
--- a/source/03-components/card/_card.scss
+++ b/source/03-components/card/_card.scss
@@ -87,6 +87,10 @@ $card-padding: 30px;
   font-size: rem(gesso-font-size(2));
   line-height: gesso-line-height(loose);
 
+  p {
+    margin-bottom: 0;
+  }
+
   &:not(:last-child) {
     padding-bottom: rem(30px);
   }

--- a/templates/content/node--event--card.html.twig
+++ b/templates/content/node--event--card.html.twig
@@ -102,8 +102,8 @@
 {% set datetime_composed %}
   {% if multiday_event == false %}
     {{ event_start_date|date("l, F j, Y") }}
-    <br>
-    {{- event_start_date|date("g:i a")|replace({"am":"a.m.", "pm":"p.m."}) }}&nbsp;&nbsp;–&nbsp;&nbsp;{{ event_end_date|date("g:i a")|replace({"am":"a.m.", "pm":"p.m."}) }}&nbsp;&nbsp;{{ event_start_date|date("T")|replace({"PST":"PT","PDT":"PT"}) -}}
+    ·
+    {{ event_start_date|date("g:i a")|replace({"am":"a.m.", "pm":"p.m."}) }}&nbsp;&nbsp;–&nbsp;&nbsp;{{ event_end_date|date("g:i a")|replace({"am":"a.m.", "pm":"p.m."}) }}&nbsp;&nbsp;{{ event_start_date|date("T")|replace({"PST":"PT","PDT":"PT"}) -}}
   {% else %}
     {{- event_start_date|date("l, F j, Y") }}&nbsp;&nbsp;–&nbsp;&nbsp;{{ event_end_date|date("l, F j, Y") }}
   {% endif %}

--- a/templates/content/node--event--large-card.html.twig
+++ b/templates/content/node--event--large-card.html.twig
@@ -100,8 +100,8 @@
 {% set datetime_composed %}
   {% if multiday_event == false %}
     {{ event_start_date|date("l, F j, Y") }}
-    <br>
-    {{- event_start_date|date("g:i a")|replace({"am":"a.m.", "pm":"p.m."}) }}&nbsp;&nbsp;–&nbsp;&nbsp;{{ event_end_date|date("g:i a")|replace({"am":"a.m.", "pm":"p.m."}) }}&nbsp;&nbsp;{{ event_start_date|date("T")|replace({"PST":"PT","PDT":"PT"}) -}}
+    ·
+    {{ event_start_date|date("g:i a")|replace({"am":"a.m.", "pm":"p.m."}) }}&nbsp;&nbsp;–&nbsp;&nbsp;{{ event_end_date|date("g:i a")|replace({"am":"a.m.", "pm":"p.m."}) }}&nbsp;&nbsp;{{ event_start_date|date("T")|replace({"PST":"PT","PDT":"PT"}) -}}
   {% else %}
     {{- event_start_date|date("l, F j, Y") }}&nbsp;&nbsp;–&nbsp;&nbsp;{{ event_end_date|date("l, F j, Y") }}
   {% endif %}


### PR DESCRIPTION
- paragraphs inside cards shouldn't have bottom margins (there's already padding)
- changes linebreak in composed date to a " · "