### PR TITLE
267 - fix misaligned search icon

### DIFF
--- a/source/03-components/search/_search.scss
+++ b/source/03-components/search/_search.scss
@@ -204,10 +204,6 @@
   right: calc(#{rem(gesso-spacing(1.5))} + 1px);
   top: calc(#{rem(gesso-spacing(1))} + 1px);
 
-  .c-search--in-page & {
-    top: calc(#{gesso-spacing(5)} + 1px + var(--gesso-search-font-size) / 2);
-  }
-
   @include breakpoint(gesso-breakpoint(mobile-menu) + 1px) {
     font-size: calc(var(--gesso-search-font-size) - 0.5rem);
     top: calc(#{rem(gesso-spacing(0.5))} + 1px + 0.25rem);


### PR DESCRIPTION
@kmonahan This fixes the bug in the in-page search used on faq pages - let me know if you're aware of any other places that class would show up in case I need to check for regressions.