### PR TITLE
270 - fix spacing in header (nav gets own line)

### DIFF
--- a/source/02-layouts/header/_header.scss
+++ b/source/02-layouts/header/_header.scss
@@ -5,7 +5,7 @@
   --gesso-scroll-progress: 0%;
   left: 0;
   position: sticky;
-  top: calc(var(--ginToolbarHeight, 0px));
+  top: calc(var(--gin-toolbar-height, 0px));
   width: 100%;
   z-index: gesso-z-index(nav);
 
@@ -74,4 +74,8 @@
   @include breakpoint(gesso-breakpoint(mobile-menu) + 1px) {
     width: 100%;
   }
+}
+
+.l-nav--main {
+  flex-basis: 100%;
 }

--- a/templates/content/node--blog--full.html.twig
+++ b/templates/content/node--blog--full.html.twig
@@ -103,13 +103,20 @@
   {% set author = link(author, content.field_link.0['#url']) %}
 {% endif %}
 
+{% set kicker %}
+{{- content.field_date|render|striptags|trim -}}
+{% if content.field_category %}
+  {{- ' · ' ~ content.field_category|field_value -}}
+{% endif %}
+{% endset %}
+
 {% include '@templates/news-article-detail/news-article-detail.twig' with {
   'title': label,
   'lede': content.field_dek|field_value,
   'show_admin_info': show_admin_info,
   'admin_info': admin_info,
   'show_footer': false,
-  'date': content.field_date|render|striptags|trim,
+  'date': kicker,
   'author': author,
   'rdf_metadata': metadata,
   'content': article_content,


### PR DESCRIPTION
this accidentally includes part of the work for another ticket (blog category); there will still be a config update for that in the other repo.

also, looks like the gin library changed its variable names on us, so a small fix to position the header correctly while logged in.