### PR TITLE
312 - small card height

### DIFF
--- a/source/03-components/card/card--small/_card--small.scss
+++ b/source/03-components/card/card--small/_card--small.scss
@@ -28,11 +28,10 @@
 
   .c-card__icon {
     border-radius: 0;
-    font-size: 70px;
+    font-size: 68px;
     height: 70px;
     margin-top: 0;
     transform: none;
-    width: 70px;
   }
 
   .c-kicker {

--- a/source/03-components/card/card--small/_card--small.scss
+++ b/source/03-components/card/card--small/_card--small.scss
@@ -5,6 +5,7 @@
 .c-card.c-card--small {
   aspect-ratio: 1;
   background: gesso-grayscale(white);
+  height: 100%;
 
   .c-card__body {
     padding: 15px 20px;


### PR DESCRIPTION
per yesterday's thorough discussion, small/square cards will now match height within rows, and it's up to content editors to limit their text to fit. i also noticed some icons get cut off - i think the explicit width was a holdover from before we implemented fontawesome. tweaked for better display.