### PR TITLE
279 - nvda reads search without aria-hidden

### DIFF
--- a/source/03-components/accordion/_accordion-item-content.twig
+++ b/source/03-components/accordion/_accordion-item-content.twig
@@ -12,7 +12,7 @@
   <span>{{ accordion_title }}</span>
   {% include '@components/icon/icon.twig' with {
     'icon_name': 'close',
-    'label': 'Open/Close Accordion',
+    'label': false,
     'modifier_classes': 'c-accordion-item__icon'
   } %}
 </button>

--- a/source/03-components/search/modules/SearchFlyout.es6.js
+++ b/source/03-components/search/modules/SearchFlyout.es6.js
@@ -37,8 +37,14 @@ class SearchFlyout {
   toggleSection(section, hide) {
     if (hide) {
       section.hidden = true;
+      section.setAttribute('aria-hidden', 'true');
     } else {
       section.hidden = !section.hidden;
+      if (section.hidden) {
+        section.setAttribute('aria-hidden', 'true');
+      } else {
+        section.removeAttribute('aria-hidden');
+      }
     }
     section.setAttribute('tabindex', section.hidden ? '-1' : '0');
     const focusable = section.querySelectorAll(
@@ -207,6 +213,7 @@ class SearchFlyout {
     button.addEventListener('click', this.handleButtonClick.bind(this));
     button.addEventListener('keydown', this.handleButtonKeydown.bind(this));
     closeButton.addEventListener('click', this.handleCloseClick.bind(this));
+    section.setAttribute('aria-hidden', 'true');
   }
 
   /**


### PR DESCRIPTION
This is a quirky one - it works as intended right now if you're using the tab key or voiceover, but specifically if you're navigating by arrow in nvda, it reads out the search fields even when they're collapsed. This seems to sort it out, but I was just testing with browser tools since my dev machine can't run nvda; I'll go back and confirm it works once merged.

also includes a fix for over-described buttons in the accordion