### PR TITLE
Fixed news behavior when there are no paragraphs

### DIFF
--- a/includes/node.inc
+++ b/includes/node.inc
@@ -107,7 +107,7 @@ function slac_preprocess_node__news_article(&$vars) {
   if ($vars['view_mode'] == 'card' || $vars['view_mode'] == 'teaser_card') {
     if (!empty($vars['content']['field_teaser'][0]) && $vars['content']['field_teaser']['#formatter'] == 'trimmed_first_wysiwyg_paragraph') {
       $is_truncated = $vars['elements']['field_teaser'][0]['#attributes']['is_truncated'];
-    } elseif (!empty($vars['node']->field_paragraphs) && $vars['content']['field_paragraphs']['#formatter'] == 'trimmed_first_wysiwyg_paragraph') {
+    } elseif (isset($vars['content']['field_paragraphs']['#formatter']) && $vars['content']['field_paragraphs']['#formatter'] == 'trimmed_first_wysiwyg_paragraph') {
       $is_truncated = $vars['elements']['field_paragraphs'][0]['#attributes']['is_truncated'];
     }
     if (isset($is_truncated)) {


### PR DESCRIPTION
When a `news_article` has no paragraphs, the card display breaks:

![image](https://github.com/user-attachments/assets/d0671a68-49fb-4938-8de4-a9c00a1cbbc2)

Here we fix the `node.inc` file to correctly check for a #formatter key before it checks the content of the key.
