### PR TITLE
Fix arrow and external links with html special entities in last word

### DIFF
--- a/source/03-components/arrow-link/arrow-link.es6.js
+++ b/source/03-components/arrow-link/arrow-link.es6.js
@@ -14,15 +14,29 @@ Drupal.behaviors.arrowLink = {
         return;
       }
 
-      const text = link.textContent.trim().split(' ');
-      const lastWord = text.pop();
-      if (lastWord) {
-        const lastWordMarkup = `<span class="c-arrow-link__word">${lastWord}</span>`;
-        const lastIndex = link.innerHTML.lastIndexOf(lastWord);
-        link.innerHTML =
-          link.innerHTML.substring(0, lastIndex) +
-          lastWordMarkup +
-          link.innerHTML.substring(lastIndex + lastWord.length);
+      // Get the deepest nested Text Node of the last child element in the
+      // link. This ensures we're accounting for markup within the <a> tag.
+      let lastTextChild = link.lastChild;
+      while (lastTextChild) {
+        if (lastTextChild.nodeType === Node.TEXT_NODE) {
+          break;
+        }
+        lastTextChild = lastTextChild.lastChild;
+      }
+
+      if (lastTextChild) {
+        const text = lastTextChild.nodeValue
+        const textArray = text.trim().split(' ');
+        const lastWord = textArray[textArray.length - 1];
+
+        if (lastWord) {
+          const lastWordMarkup = `<span class="c-arrow-link__word">${lastWord}</span>`;
+          const lastIndex = text.lastIndexOf(lastWord);
+          link.innerHTML =
+            text.substring(0, lastIndex) +
+            lastWordMarkup +
+            text.substring(lastIndex + lastWord.length);
+        }
       }
     });
   },

--- a/source/03-components/arrow-link/arrow-link.yml
+++ b/source/03-components/arrow-link/arrow-link.yml
@@ -1,3 +1,3 @@
 ---
-link_text: 'Arrow Link'
+link_text: 'Arrow Link (Q&A)'
 link_url: '#0'

--- a/source/03-components/external-link/external-link.es6.js
+++ b/source/03-components/external-link/external-link.es6.js
@@ -65,23 +65,37 @@ Drupal.behaviors.externalLinks = {
 
     externalLinks.forEach(el => {
       if (el.hasAttribute('href') && !el.querySelector('img')) {
-        const text = el.textContent.trim().split(' ');
-        const lastWord = text.pop();
-        if (lastWord) {
-          let lastWordMarkup = lastWord;
-          if (linkIsLocked(el)) {
-            lastWordMarkup = `<span class="external-link__word">${lastWord}<svg class="c-icon" role="img"><title>(requires login)</title><use xlink:href="${drupalSettings.gesso.gessoImagePath}/sprite.artifact.svg#lock-solid"></use></svg></span>`;
-            el.classList.add('external-link', 'external-link--locked');
-          } else if (linkIsExternal(el)) {
-            lastWordMarkup = `<span class="external-link__word">${lastWord}<svg class="c-icon" role="img"><title>(external link)</title><use xlink:href="${drupalSettings.gesso.gessoImagePath}/sprite.artifact.svg#diagonal-arrow"></use></svg></span>`;
-            el.classList.add('external-link');
+        // Get the deepest nested Text Node of the last child element in the
+        // link. This ensures we're accounting for markup within the <a> tag.
+        let lastTextChild = el.lastChild;
+        while (lastTextChild) {
+          if (lastTextChild.nodeType === Node.TEXT_NODE) {
+            break;
           }
-          const lastIndex = el.innerHTML.lastIndexOf(lastWord);
-          el.innerHTML =
-            el.innerHTML.substring(0, lastIndex) +
-            lastWordMarkup +
-            el.innerHTML.substring(lastIndex + lastWord.length);
+          lastTextChild = lastTextChild.lastChild;
         }
+        if (lastTextChild) {
+          const text = lastTextChild.nodeValue
+          const textArray = text.trim().split(' ');
+          const lastWord = textArray[textArray.length - 1];
+
+          if (lastWord) {
+            let lastWordMarkup = lastWord;
+            if (linkIsLocked(el)) {
+              lastWordMarkup = `<span class="external-link__word">${lastWord}<svg class="c-icon" role="img"><title>(requires login)</title><use xlink:href="${drupalSettings.gesso.gessoImagePath}/sprite.artifact.svg#lock-solid"></use></svg></span>`;
+              el.classList.add('external-link', 'external-link--locked');
+            } else if (linkIsExternal(el)) {
+              lastWordMarkup = `<span class="external-link__word">${lastWord}<svg class="c-icon" role="img"><title>(external link)</title><use xlink:href="${drupalSettings.gesso.gessoImagePath}/sprite.artifact.svg#diagonal-arrow"></use></svg></span>`;
+              el.classList.add('external-link');
+            }
+            const lastIndex = text.lastIndexOf(lastWord);
+            el.innerHTML =
+              text.substring(0, lastIndex) +
+              lastWordMarkup +
+              text.substring(lastIndex + lastWord.length);
+          }
+        }
+
       }
     });
   },

--- a/source/03-components/external-link/external-link.twig
+++ b/source/03-components/external-link/external-link.twig
@@ -12,14 +12,17 @@
   <p><a href="https://sites.slac.stanford.edu/cro/resources">https://sites.slac.stanford.edu/cro/resources</a></p>
   <p><a href="https://emergency.slac.stanford.edu/coronavirus">https://emergency.slac.stanford.edu/coronavirus</a></p>
   <p><a href="https://careers.slac.stanford.edu/">https://careers.slac.stanford.edu/</a></p>
+  <p><a href="https://esh.slac.stanford.edu/">Example with ampersand: ES&H</a></p>
 
 
   <h2>Locked Links</h2>
   <p><a href="https://intranet.slac.stanford.edu/">https://intranet.slac.stanford.edu/</a></p>
+  <p><a href="https://int.slac.stanford.edu/ttsp">Example with ampersand: TT&SP</a></p>
 
   <h2>External Links</h2>
   <p><a href="http://www.stanford.edu/">http://www.stanford.edu/</a></p>
   <p><a href="https://www.symmetrymagazine.org">https://www.symmetrymagazine.org</a></p>
+  <p><a href="https://www.energy.gov/prices-trends">Example with ampersand: Prices&Trends</a></p>
 
   <h2>External and Locked Links with No Icon</h2>
   <p><a class="external-link--no-icon" href="http://www.stanford.edu/">http://www.stanford.edu/</a></p>


### PR DESCRIPTION
We'll now traverse link elements to find the last Text Node of the element, rather than working with textContent and innerHTML. This allows us to work with nodeValue, which remains unescaped. It also allows us to act on links that have markup in the text.
