### PR TITLE
If a last word has already been found, use that

### DIFF
--- a/source/03-components/arrow-link/arrow-link.es6.js
+++ b/source/03-components/arrow-link/arrow-link.es6.js
@@ -14,14 +14,25 @@ Drupal.behaviors.arrowLink = {
         return;
       }
 
-      // Get the deepest nested Text Node of the last child element in the
-      // link. This ensures we're accounting for markup within the <a> tag.
-      let lastTextChild = link.lastChild;
-      while (lastTextChild) {
-        if (lastTextChild.nodeType === Node.TEXT_NODE) {
-          break;
+      // Check if this element already has a child span with a *.__word class.
+      let lastTextChild = null;
+      const existingWordSpan = link.querySelector('[class$="__word"]');
+      if (existingWordSpan) {
+        // Move the last word text content out of the existing *.__word span, then remove the span.
+        lastTextChild = existingWordSpan.firstChild;
+        existingWordSpan.parentElement.appendChild(lastTextChild);
+        existingWordSpan.remove();
+      }
+      else {
+        // Get the deepest nested Text Node of the last child element in the
+        // link. This ensures we're accounting for markup within the <a> tag.
+        lastTextChild = link.lastChild;
+        while (lastTextChild) {
+          if (lastTextChild.nodeType === Node.TEXT_NODE) {
+            break;
+          }
+          lastTextChild = lastTextChild.lastChild;
         }
-        lastTextChild = lastTextChild.lastChild;
       }
 
       if (lastTextChild) {

--- a/source/03-components/external-link/external-link.es6.js
+++ b/source/03-components/external-link/external-link.es6.js
@@ -68,15 +68,27 @@ Drupal.behaviors.externalLinks = {
 
     externalLinks.forEach(el => {
       if (el.hasAttribute('href') && !el.querySelector('img')) {
-        // Get the deepest nested Text Node of the last child element in the
-        // link. This ensures we're accounting for markup within the <a> tag.
-        let lastTextChild = el.lastChild;
-        while (lastTextChild) {
-          if (lastTextChild.nodeType === Node.TEXT_NODE) {
-            break;
-          }
-          lastTextChild = lastTextChild.lastChild;
+        // Check if this element already has a child span with a *.__word class.
+        let lastTextChild = null;
+        const existingWordSpan = el.querySelector('[class$="__word"]');
+        if (existingWordSpan) {
+          // Move the last word text content out of the existing *.__word span, then remove the span.
+          lastTextChild = existingWordSpan.firstChild;
+          existingWordSpan.parentElement.appendChild(lastTextChild);
+          existingWordSpan.remove();
         }
+        else {
+         // Get the deepest nested Text Node of the last child element in the
+         // link. This ensures we're accounting for markup within the <a> tag.
+         lastTextChild = el.lastChild;
+         while (lastTextChild) {
+           if (lastTextChild.nodeType === Node.TEXT_NODE) {
+             break;
+           }
+           lastTextChild = lastTextChild.lastChild;
+         }
+        }
+
         if (lastTextChild) {
           const text = lastTextChild.parentElement.innerHTML;
           const textArray = text.trim().split(' ');


### PR DESCRIPTION
When a link is both an arrow link and an external link, there were certain cases where our detection of the last word was not working as expected. Since the arrow link has already identified the last word, let's just use that text content and remove the arrow link span.