### PR TITLE
Support putting event details behind auth wall

### DIFF
--- a/includes/node.inc
+++ b/includes/node.inc
@@ -51,8 +51,8 @@ function slac_preprocess_node(&$variables) {
 }
 
 /**
-* Custom function to add page regions to templates.
-*/
+ * Custom function to add page regions to templates.
+ */
 function _add_regions_to_template($allowed_regions, &$variables) {
   // Get active theme.
   $theme = \Drupal::theme()->getActiveTheme()->getName();
@@ -66,8 +66,8 @@ function _add_regions_to_template($allowed_regions, &$variables) {
   foreach ($regions as $key => $region) {
     // Load blocks from this region and sort them.
     $blocks = \Drupal::entityTypeManager()
-      ->getStorage('block')
-      ->loadByProperties(array('theme'  => $theme, 'region' => $region));
+        ->getStorage('block')
+        ->loadByProperties(array('theme'  => $theme, 'region' => $region));
     uasort($blocks, 'Drupal\block\Entity\Block::sort');
 
     // Build blocks and assign to template variable.
@@ -90,11 +90,11 @@ function slac_preprocess_node__person(&$vars) {
     if (!empty($vars['content']['field_body'][0])) {
       $body_field = $vars['elements']['#node']->get('field_body');
       $vars['content']['field_body_trimmed'] = $body_field->view([
-        'type' => 'text_trimmed',
-        'label' => 'hidden',
-        'settings' => [
-          'trim_length' => 500
-        ],
+          'type' => 'text_trimmed',
+          'label' => 'hidden',
+          'settings' => [
+              'trim_length' => 500
+          ],
       ]);
     }
   }
@@ -118,16 +118,16 @@ function slac_preprocess_node__news_article(&$vars) {
     $node = $vars['elements']['#node'];
     if (!$node->field_text->value && $node->field_link->first()) {
       /** @var Url $url */
-     $url = $node->field_link->first()->getUrl();
-     if ($url->getRouteName() === 'entity.node.canonical') {
-       $nid = $url->getRouteParameters()['node'];
-       $node = Node::load($nid);
-       if ($node->bundle() === 'person') {
-         $vars['content']['field_text'] = $node->get('title')->view();
-         $renderer = \Drupal::service('renderer');
-         $renderer->addCacheableDependency($vars, $node);
-       }
-     }
+      $url = $node->field_link->first()->getUrl();
+      if ($url->getRouteName() === 'entity.node.canonical') {
+        $nid = $url->getRouteParameters()['node'];
+        $node = Node::load($nid);
+        if ($node->bundle() === 'person') {
+          $vars['content']['field_text'] = $node->get('title')->view();
+          $renderer = \Drupal::service('renderer');
+          $renderer->addCacheableDependency($vars, $node);
+        }
+      }
     }
   }
 }
@@ -137,4 +137,11 @@ function slac_preprocess_node__news_article(&$vars) {
  */
 function slac_preprocess_node__blog(&$vars) {
   slac_preprocess_node__news_article($vars);
+}
+
+function slac_preprocess_node__event(&$vars) {
+  $node = $vars['node'];
+  if (method_exists($node, 'getOutlookLink') && isset($vars['content']['field_smart_date'][0]['addtocal']['#outlook'])) {
+    $vars['content']['field_smart_date'][0]['addtocal']['#outlook'] = $node->getOutlookLink();
+  }
 }

--- a/source/03-components/event-details/event-details.scss
+++ b/source/03-components/event-details/event-details.scss
@@ -39,6 +39,13 @@
   &:not(:last-child) {
     border-bottom: 1px solid gesso-grayscale(gray-4);
   }
+
+  .c-event-details__authentication {
+    p {
+      font-size: gesso-font-size(2);
+      margin-bottom: 0;
+    }
+  }
 }
 
 .c-event-details__when,

--- a/source/03-components/event-details/event-details.twig
+++ b/source/03-components/event-details/event-details.twig
@@ -1,66 +1,79 @@
 {% set classes = [
-  'c-event-details',
-  is_past_event ? 'c-event-details--past' : '',
-  modifier_classes ? modifier_classes : ''
+    'c-event-details',
+    is_past_event ? 'c-event-details--past' : '',
+    modifier_classes ? modifier_classes : ''
 ] %}
+
+{% set display_authenticated_content = node.isAuthenticatedUser() %}
 
 {{ attach_library('slac/event_details') }}
 
 <div {{ add_attributes({ class: classes } ) }}>
 
-  <div class="c-event-details__image">
-    {% if image %}
-      {{ image }}
-      <div class="c-card__gradient"></div>
-    {% endif %}
-    {% if start_date %}
-      {% include '@components/event-date/event-date.twig' %}
-    {% endif %}
-  </div>
-
-  <div class="c-event-details__section">
-    {% include '@components/page-title/page-title.twig' with {
-      kicker: event_type,
-      page_title: event_title,
-      lede: speaker_info
-    } %}
-    {% if calendar_link_text %}
-      <div class="c-event-details__when">
-      {% if not is_past_event %}{% include '@components/icon/icon.twig' with {
-          label: 'Date',
-          icon_name: 'calendar',
-        } %}{% endif %}
-        <span{% if is_past_event %} class="is-past-event"{% endif %}>
-          {{ calendar_link_text }}
-        </span>
-      </div>
-    {% endif %}
-
-    {% if map_link_text and not is_past_event %}
-      <div class="c-event-details__where">
-        {% include '@components/icon/icon.twig' with {
-            label: 'Location',
-            icon_name: 'location',
-          } %}
-        {% if map_link_url  %}
-          <a href="{{ map_link_url }}" title="{{ 'Get directions'|t }}" class="c-event-details__link">
-            {{ map_link_text }}
-          </a>
-        {% else %}
-          {{ map_link_text }}
+    <div class="c-event-details__image">
+        {% if image %}
+            {{ image }}
+            <div class="c-card__gradient"></div>
         {% endif %}
-      </div>
-    {% endif %}
+        {% if start_date %}
+            {% include '@components/event-date/event-date.twig' %}
+        {% endif %}
+    </div>
 
-    {% if zoom_url and not is_past_event %}
-      <div class="c-event-details__virtual">
-        {% include '@components/icon/icon.twig' with {
-          label: 'Virtual event',
-          icon_name: 'virtual'
+    <div class="c-event-details__section">
+        {% include '@components/page-title/page-title.twig' with {
+            kicker: event_type,
+            page_title: event_title,
+            lede: speaker_info
         } %}
-        <a href="{{ zoom_url }}" class="c-event-details__link">{{ zoom_text|default('Join us on Zoom'|t) }}</a>
-      </div>
-    {% endif %}
-  </div>
+
+        {% if calendar_link_text %}
+            <div class="c-event-details__when">
+                {% if not is_past_event %}{% include '@components/icon/icon.twig' with {
+                    label: 'Date',
+                    icon_name: 'calendar',
+                } %}{% endif %}
+                <span{% if is_past_event %} class="is-past-event"{% endif %}>
+          {% if not display_authenticated_content %}
+              {{ calendar_link_text[0]|without('addtocal') }}
+          {% else %}
+              {{ calendar_link_text }}
+          {% endif %}
+        </span>
+            </div>
+        {% endif %}
+
+        {% if map_link_text and not is_past_event and display_authenticated_content %}
+            <div class="c-event-details__where">
+                {% include '@components/icon/icon.twig' with {
+                    label: 'Location',
+                    icon_name: 'location',
+                } %}
+                {% if map_link_url  %}
+                    <a href="{{ map_link_url }}" title="{{ 'Get directions'|t }}" class="c-event-details__link">
+                        {{ map_link_text }}
+                    </a>
+                {% else %}
+                    {{ map_link_text }}
+                {% endif %}
+            </div>
+        {% endif %}
+
+        {% if zoom_url and not is_past_event and display_authenticated_content %}
+            <div class="c-event-details__virtual">
+                {% include '@components/icon/icon.twig' with {
+                    label: 'Virtual event',
+                    icon_name: 'virtual'
+                } %}
+                <a href="{{ zoom_url }}" class="c-event-details__link">{{ zoom_text|default('Join us on Zoom'|t) }}</a>
+            </div>
+        {% endif %}
+
+        {% if not display_authenticated_content and not is_past_event %}
+            <div class="c-event-details__authentication">
+                <p>{{ node.getAuthenticationMessage() }}</p>
+            </div>
+        {% endif %}
+    </div>
 
 </div>


### PR DESCRIPTION
To use this functionality on a site, add a `field_require_auth` field to the Event content type.

See also: https://github.com/SLAC/slac-drupal-profile/pull/132