### PR TITLE
Ensure updated logo is displayed and CSS is loaded in correct order

### DIFF
--- a/slac.libraries.yml
+++ b/slac.libraries.yml
@@ -2,6 +2,7 @@ global:
   css:
     theme:
       //fonts.googleapis.com/css2?family=Lato:ital,wght@0,300;0,400;0,500;0,700;0,900;1,300;1,400;1,700;1,900&family=Merriweather:ital,wght@0,300;0,400;0,700;0,900;1,300;1,400;1,700;1,900&display=swap: { type: external }
+    base:
       dist/css/styles.css: {}
   js:
     dist/js/arrow-link.es6.js: {}

--- a/source/02-layouts/subfooter/subfooter.twig
+++ b/source/02-layouts/subfooter/subfooter.twig
@@ -50,7 +50,7 @@
         'height': 48
       } %}
         {% include '@components/logo/logo.twig' with {
-        'logo': gesso_image_path ~ '/DOE_logo.png',
+        'logo': gesso_image_path ~ '/DOE_logo.png?v=2025',
         'url': 'https://science.energy.gov/',
         'title': 'U.S. Department of Energy',
         'loading': 'lazy',


### PR DESCRIPTION
Adding a query parameter to cache the updated logo in the CDN.

Change styles.css to a base weight to ensure it's loaded in the order overriding stylesheets expect.
